### PR TITLE
Rework make file, fix 'make install'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,29 +17,30 @@ CFLAGS:=-std=gnu11 -I$(INCLUDES) $(shell pkg-config --libs --cflags cairo x11 xf
 CFILES:=$(shell find $(SOURCES) -printf '%P ' -name '*.c')
 OFILES:=$(patsubst %.c,$(BUILD)/%.o,$(CFILES))
 
-.PHONY: install build debug clean mkdir
+.PHONY: build
 .DEFAULT_GOAL:=build
 
 install: build
 	cd ./connmap/resources && unzip -n ipv4.csv.zip
 	cp -R ./connmap ~/.config/
+	cp connmap.elf ~/.local/bin/connmap
 
 build: CFLAGS+=-O0
 build: mkdir $(OFILES)
-	$(CC) $(OFILES) -o $(TARGET).exe $(CFLAGS)
+	$(CC) $(OFILES) -o $(TARGET).elf $(CFLAGS)
 
 debug: CFLAGS+=-O0 -ggdb -D DEBUG
 debug: mkdir $(OFILES)
-	$(CC) $(OFILES) -o $(TARGET).debug.exe $(CFLAGS)
+	$(CC) $(OFILES) -o $(TARGET).debug.elf $(CFLAGS)
 
 mkdir:
 	mkdir -p $(BUILD)
 
 clean:
-	rm -rf $(BUILD)
-	rm -f $(TARGET).exe
-	rm -f $(TARGET).debug.exe
-	rm -f ./connmap/resources/ipv4.csv
+	-rm -rf $(BUILD)
+	-rm -f $(TARGET).elf
+	-rm -f $(TARGET).debug.elf
+	-rm -f ./connmap/resources/ipv4.csv
 
 $(OFILES): $(BUILD)/%.o: $(SOURCES)/%.c
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ CFLAGS:=-std=gnu11 -I$(INCLUDES) $(shell pkg-config --libs --cflags cairo x11 xf
 CFILES:=$(shell find $(SOURCES) -printf '%P ' -name '*.c')
 OFILES:=$(patsubst %.c,$(BUILD)/%.o,$(CFILES))
 
-.PHONY: build
+.PHONY: install build debug clean mkdir
 .DEFAULT_GOAL:=build
 
 install: build

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ connmap is an X11 desktop widget that shows location of your current network pee
 </p>
 
 ## Installation
-Clone the repository `git clone https://github.com/jafarlihi/connmap --depth 1`, run `make install`, then run the resulting executable `./connmap.exe`.
+Clone the repository `git clone https://github.com/jafarlihi/connmap --depth 1`, run `make install`, then run the resulting executable `./connmap.elf`.
 
 ## Dependencies
 Build dependencies: xlib, libcairo2


### PR DESCRIPTION
General makefile fixes.

- ``make install`` copies binary to ~/.local/bin
- ``make clean`` wont fail if debug (or normal) binaries don't exist.